### PR TITLE
增加无数据退出功能，避免资源浪费

### DIFF
--- a/function/search.py
+++ b/function/search.py
@@ -59,6 +59,9 @@ class Search():
 
         # 网页解析
         html = BeautifulSoup(text, 'lxml')
+        # 如果页面出现了not-found(无数据)提示，返回None给上一层，让上一层的for循环退出
+        if html.select(".not-found-right"):
+            return None
         shop_all_list = html.select('.shop-list')[0].select('li')
 
         search_res = []

--- a/utils/spider_controller.py
+++ b/utils/spider_controller.py
@@ -80,6 +80,9 @@ class Controller():
             }
             """
             search_res = self.s.search(search_url, request_type)
+            # search方法如果返回None，代表页面已经没有数据了
+            if not search_res:
+                break
 
             if spider_config.NEED_DETAIL is False and spider_config.NEED_REVIEW is False:
                 for each_search_res in search_res:
@@ -187,6 +190,9 @@ class Controller():
                         each_review_res.pop('推荐菜')
 
                 self.saver(each_search_res, each_review_res)
+            # 如果这一页数据小于15，代表下一页已经没有数据了，直接退出
+            if len(search_res) < 15:
+                break
 
     def get_review(self, shop_id, detail=False):
         if detail:


### PR DESCRIPTION
运行时发现搜索50页的时候，即使**没有数据了，依然会持续搜索到50页**。
这里用了**判断当前页面数据量**（数据量是否不够一页的数据15条）及**页面是否出现not-found**（无数据提示）提示判断是否应该退出页面查询的for循环。